### PR TITLE
fix(react): resolve React error #310 by refactoring formatTime

### DIFF
--- a/react/src/components/NoteTree.jsx
+++ b/react/src/components/NoteTree.jsx
@@ -51,7 +51,7 @@ export default function NoteTree({
             </span>
             {node.postId && (
               <>
-                <span style={{ marginLeft: 8, fontSize: 12, color: '#888' }}>{formatTime(node.updatedAt)}</span>
+                <span style={{ marginLeft: 8, fontSize: 12, color: '#888' }}>{formatTime(node.updatedAt, t)}</span>
                 {showMenuBtn &&
                   <div style={{ position: 'relative', marginLeft: 6 }}>
                     <button

--- a/react/src/components/RelatedNotes.jsx
+++ b/react/src/components/RelatedNotes.jsx
@@ -26,7 +26,7 @@ export default function RelatedNotes({ relatedPosts }) {
               {rp.title}
             </div>
             <div style={{ color: '#888', fontSize: 12 }}>
-              {formatTime(rp.updated_at)}
+              {formatTime(rp.updated_at, t)}
             </div>
           </div>
         ))}

--- a/react/src/utils/formatTime.js
+++ b/react/src/utils/formatTime.js
@@ -1,8 +1,6 @@
 // src/utils/formatTime.js
-import { useTranslation } from 'react-i18next';
 
-export default function formatTime(dateString) {
-    const { t } = useTranslation();
+export default function formatTime(dateString, t) {
     const date = new Date(dateString);
     const now = new Date();
     const msPerDay = 24 * 60 * 60 * 1000;
@@ -14,4 +12,3 @@ export default function formatTime(dateString) {
     if (diffDays < 7) return t('days_ago', { count: diffDays });
     return date.toLocaleDateString();
   }
-  


### PR DESCRIPTION
- Pass the `t` function as a parameter to `formatTime` to avoid calling the `useTranslation` hook in a non-component function.
- Update calls to `formatTime` in `NoteTree.jsx` and `RelatedNotes.jsx` to pass the `t` function.

Fixes #26

Authored-by : Gemini CLI